### PR TITLE
chore: bump version to 3.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "testing-platform"
-version = "2.1.1"
+version = "3.0.1"
 description = "NC3 Testing Platform"
 authors = [
     "Romain Kieffer <romain.kieffer@nc3.lu>",


### PR DESCRIPTION
## Generic requirements in order to contribute:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch
* Any major changes adding a functionality should be disabled by default in the configuration


#### What does it do?

Bumps the version in `pyproject.toml` from `2.1.1` to `3.0.1` to align with the current git tag scheme (latest tag was already `v3.0.0`). This makes the footer version display consistent.

Follows on from #48 (Python 3.13 compatibility upgrade).

#### Questions

- [ ] Does it require a DB change? **No**
- [ ] Are you using it in production? **No**

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch